### PR TITLE
Check env

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+[ -z "$DEPLOY_TASKS" ] && { echo "DEPLOY_TASKS has not been set"; exit 1; }
 set -e            # fail fast
 set -o pipefail   # don't ignore exit codes when piping output
 


### PR DESCRIPTION
Exit the script with a more clear error message when $DEPLOY_TASKS is not set
