### PR TITLE
Making the deploy tasks optional

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,11 +17,11 @@ if [ -d "$env_dir" ]; then
   done
 fi
 
-if [ -z "$DEPLOY_TASKS" ]; then 
+if [ -z "$DEPLOY_TASKS" ]; then
   echo "DEPLOY_TASKS has not been set"
-  echo "You can set it with:" 
+  echo "You can set it with:"
   echo 'heroku config:set DEPLOY_TASKS="tasks to run"'
-  exit 1 
+  exit 0
 fi
 
 cd $build_dir && bundle exec rake $DEPLOY_TASKS


### PR DESCRIPTION
When we have a staging server with an inconsistent database it's really annoying having a long deploy fail because the `DEPLOY_TASK` isn't set.
