### PR TITLE
Clarify README to ensure buildpack is appended

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This buildpack is intended for use after the regular [ruby-buildpack].
 
 # Usage
 
+If you are using the default buildpack, manually set your buildpack to Heroku's default Ruby buidlpack
+
+```
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby
+```
+
 Append the buildpack-ruby-rake-deploy-tasks to your buildpack list:
 
 ```


### PR DESCRIPTION
If using the Heroku ruby buildpack by default, for some reason just running buildpacks:add actually overrides it to be the only buildpack (at least for me). Manually setting the buildpack first, then running buildpacks:add ensures it will be appended _after_ the default.
