### PR TITLE
Removed bundle exec and properly handled multiple tasks.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,4 +24,8 @@ if [ -z "$DEPLOY_TASKS" ]; then
   exit 0
 fi
 
-cd $build_dir && bundle exec rake $DEPLOY_TASKS
+tasks=(`echo ${DEPLOY_TASKS}`)
+cd $build_dir
+for task in ${tasks[@]}; do
+  rake $task
+done


### PR DESCRIPTION
Multiple tasks are still separated by a space in the DEPLOY_TASKS environment variable.
